### PR TITLE
Add SPACE_TO_DEPTH support for STATIC_WI8_AI16 quantization

### DIFF
--- a/ai_edge_quantizer/algorithms/uniform_quantize/op_architecture_tests/space_to_depth_test.py
+++ b/ai_edge_quantizer/algorithms/uniform_quantize/op_architecture_tests/space_to_depth_test.py
@@ -57,7 +57,9 @@ class SpaceToDepthTest(op_test_utils.BaseQuantizeTest):
       # get_tensor_quant_params_func, activations_num_bits, symmetric
       (naive_min_max_quantize.get_tensor_quant_params, 8, True),
       (naive_min_max_quantize.get_tensor_quant_params, 8, False),
+      (naive_min_max_quantize.get_tensor_quant_params, 16, True),
       (octav.get_tensor_quant_params, 8, True),
+      (octav.get_tensor_quant_params, 16, True),
   )
   def test_materialize_space_to_depth_succeeds(
       self, get_tensor_quant_params_func, activations_num_bits, symmetric

--- a/ai_edge_quantizer/default_policy.py
+++ b/ai_edge_quantizer/default_policy.py
@@ -200,7 +200,8 @@ DEFAULT_JSON_POLICY = """
       "EQUAL",
       "NOT_EQUAL",
       "MIRROR_PAD",
-      "RELU"
+      "RELU",
+      "SPACE_TO_DEPTH"
     ],
     "static_wi8_ai8": [
       "ADD",

--- a/ai_edge_quantizer/tests/end_to_end_tests/space_to_depth_test.py
+++ b/ai_edge_quantizer/tests/end_to_end_tests/space_to_depth_test.py
@@ -23,6 +23,7 @@ import absl.testing.absltest as absltest
 from ai_edge_quantizer import qtyping
 from ai_edge_quantizer import quantizer
 from ai_edge_quantizer.utils import test_utils
+from ai_edge_quantizer.utils import tfl_interpreter_utils
 
 
 _TEST_MODEL_FOLDER = test_utils.get_path_to_datafile('../models/')
@@ -59,6 +60,40 @@ class SpaceToDepthTest(test_utils.BaseOpTestCase):
         op_config=op_config,
         output_tolerance=output_tolerance,
     )
+
+  @parameterized.parameters(
+      # algorithm_key
+      _QuantAlgo.MIN_MAX_UNIFORM_QUANT,
+      _QuantAlgo.OCTAV,
+  )
+  def test_static_quantization_i16_succeeds(self, algorithm_key):
+    """Verifies that 16-bit quantization produces a valid quantized model.
+
+    The LiteRT runtime does not yet support INT16 for SPACE_TO_DEPTH, so
+    accuracy validation via the interpreter is not possible. This test
+    verifies that quantization completes successfully.
+    """
+    model_filename = 'single_space_to_depth.tflite'
+    model_path = str(pathlib.Path(_TEST_MODEL_FOLDER) / model_filename)
+
+    activation_config = test_utils.get_static_activation_quant_setting(
+        num_bits=16, symmetric=True
+    )
+    op_config = test_utils.get_static_op_quant_config(activation_config)
+    qt = quantizer.Quantizer(model_path)
+    qt.update_quantization_recipe(
+        algorithm_key=algorithm_key,
+        regex='.*',
+        operation_name=self._op_name,
+        op_config=op_config,
+    )
+    calibration_data = tfl_interpreter_utils.create_random_normal_input_data(
+        model_path
+    )
+    calibration_result = qt.calibrate(calibration_data)
+    quant_result = qt.quantize(calibration_result)
+    self.assertIsNotNone(quant_result.quantized_model)
+    self.assertGreater(len(quant_result.quantized_model), 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Add SPACE_TO_DEPTH to the `static_wi8_ai16` operator list in the default policy
- No algorithm changes needed — the operator already uses `materialize_standard_op()` with `SAME_AS_INPUT_SCALE` constraint (same as RESHAPE and TRANSPOSE which support 16-bit)
- Add 16-bit activation test cases to architecture and E2E tests

## Test plan
- [x] Architecture tests pass for both `naive_min_max` and `octav` with 16-bit activations
- [x] E2E test verifies quantization produces a valid model (interpreter-based accuracy validation skipped since the LiteRT runtime kernel does not yet support INT16 for SPACE_TO_DEPTH)
- [x] All existing 8-bit tests continue to pass