### PR TITLE
fix: handle N-D tensors in large-tensor CHANNELWISE quantization

### DIFF
--- a/ai_edge_quantizer/algorithms/uniform_quantize/uniform_quantize_tensor.py
+++ b/ai_edge_quantizer/algorithms/uniform_quantize/uniform_quantize_tensor.py
@@ -331,6 +331,16 @@ def uniform_quantize(
     # dimensions.
     output_shape = tensor_data.shape
     tensor_data = tensor_data.reshape([-1, output_shape[-1]])
+    # For N-D tensors (N>2), scales/zero_points must be flattened to 2D
+    # before broadcasting. Broadcast through the original leading dims
+    # first so each scale value is repeated across the correct rows.
+    if scales.ndim > 2:
+      scales = np.broadcast_to(
+          scales, output_shape[:-1] + (scales.shape[-1],)
+      ).reshape(-1, scales.shape[-1])
+      zero_points = np.broadcast_to(
+          zero_points, output_shape[:-1] + (zero_points.shape[-1],)
+      ).reshape(-1, zero_points.shape[-1])
     scales = np.broadcast_to(scales, tensor_data.shape)
     zero_points = np.broadcast_to(zero_points, tensor_data.shape)
     ret = np.zeros(shape=tensor_data.shape, dtype=_get_numpy_dtype(qtype))


### PR DESCRIPTION
## Summary

Fixes `np.broadcast_to` crash when CHANNELWISE-quantizing tensors with 3+ dimensions that exceed the 32 MiB large-tensor threshold.

**Root cause:** The large-tensor optimization in `uniform_quantize()` reshapes tensors from N-D to 2D (`tensor_data.reshape([-1, last_dim])`) for chunked processing, but does not reshape `scales`/`zero_points` before calling `np.broadcast_to(scales, tensor_data.shape)`. For 3D tensors like Gemma 4's `position_embedding_table` (shape `[2, 10240, 768]`), `scales` has shape `[2, 1, 1]` after `fix_quantization_params_rank`, and broadcasting `[2, 1, 1]` to `[20480, 768]` fails.

**Fix:** Before the final `broadcast_to`, check if `scales.ndim > 2` and if so, broadcast through the original leading dimensions first, then flatten to 2D. This ensures each scale value is correctly repeated across the rows it covers in the flattened tensor.

## Affected models

- **Gemma 4 E4B vision encoder** — `position_embedding_table` shape `[2, 10240, 768]` (~60 MB, triggers the >32 MiB branch)
- **Stable Diffusion v1.5 UNet** — reported in #472 with the same `broadcast_to` crash
- Any model with `EMBEDDING_LOOKUP` or other ops that have 3D+ weight tensors exceeding 32 MiB

## Verification

Tested by quantizing the Gemma 4 E4B vision encoder tflite with `DYNAMIC_WI8_AFP32`:
- Before fix: `ValueError: input operand has more dimensions than allowed by the axis remapping`
- After fix: quantization completes in 4s, output is 177 MB (from 677 MB FP32, 3.8x compression)
- The quantized vision encoder runs correctly on-device via LiteRT-LM

Fixes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)