### PR TITLE
Include JSON recipe and policy data files in built wheel distributions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,5 +59,8 @@ version = {file = ["VERSION"]}
 [tool.setuptools.packages.find]
 include = ["ai_edge_quantizer*"]
 
+[tool.setuptools.package-data]
+"ai_edge_quantizer" = ["recipes/*.json", "policies/*.json"]
+
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib -n auto --dist loadfile"


### PR DESCRIPTION
By default, setuptools excludes non-Python files inside directories that lack
an __init__.py file. Adding the `[tool.setuptools.package-data]` block to
pyproject.toml explicitly packages the required JSON recipes and policies,
resolving the FileNotFoundError when running `aeq` installed from the wheel.

Manually verified that the repro in http://b/513042322#comment2 now passes.

BUG=b/513042322
TAG=agy
CONV=c0b1015b-d273-4dce-bd7e-75045fd0b3c4
