### PR TITLE
Fix per-channel scales broadcasting for large tensors in chunked quantization path

### DIFF
--- a/ai_edge_quantizer/algorithms/uniform_quantize/uniform_quantize_tensor.py
+++ b/ai_edge_quantizer/algorithms/uniform_quantize/uniform_quantize_tensor.py
@@ -331,8 +331,15 @@ def uniform_quantize(
     # dimensions.
     output_shape = tensor_data.shape
     tensor_data = tensor_data.reshape([-1, output_shape[-1]])
-    scales = np.broadcast_to(scales, tensor_data.shape)
-    zero_points = np.broadcast_to(zero_points, tensor_data.shape)
+    # Broadcast to the *original* shape first so per-channel scales (e.g.
+    # (O,1,1,1)) can broadcast correctly, then reshape to 2D.  The
+    # intermediate broadcast_to returns a view (zero-copy).
+    scales = np.broadcast_to(scales, output_shape).reshape(
+        [-1, output_shape[-1]]
+    )
+    zero_points = np.broadcast_to(zero_points, output_shape).reshape(
+        [-1, output_shape[-1]]
+    )
     ret = np.zeros(shape=tensor_data.shape, dtype=_get_numpy_dtype(qtype))
 
     # Use a chunk size corresponding to 32 MiB of input data.


### PR DESCRIPTION
## Summary

Fixes #512

The chunked quantization path in `uniform_quantize_tensor.py` (for tensors > 32 MiB) reshapes `tensor_data` to 2D first, then tries to broadcast `scales` and `zero_points` to the 2D shape. This fails for per-channel quantization where scales have shapes like `(O, 1, 1, 1)` because they can't broadcast directly from `(O, 1, 1, 1)` to `(O*H*W, C)` — trailing dimensions `1` vs `C` are incompatible.

## Fix

Broadcast `scales` and `zero_points` to the **original** tensor shape first (which correctly handles per-channel shapes), then reshape to 2D:

```python
# Before (broken for per-channel):
tensor_data = tensor_data.reshape([-1, output_shape[-1]])
scales = np.broadcast_to(scales, tensor_data.shape)

# After (handles all cases):
tensor_data = tensor_data.reshape([-1, output_shape[-1]])
scales = np.broadcast_to(scales, output_shape).reshape([-1, output_shape[-1]])
```

`np.broadcast_to` returns a view (zero-copy), so no additional memory overhead.

## Test Plan

- [x] Existing 34 tests in `uniform_quantize_tensor_test.py` all pass
- [x] Verified on real models: 9 ONNX models with large tensors (>32 MiB) and per-channel weights that previously crashed now quantize successfully with cosine similarity 1.0000